### PR TITLE
Fix probabilities returned by label_components

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,17 +29,17 @@ Enhancements
 Bug
 ~~~
 
-- 
+- Fix shape of ``'y_pred_proba'`` output from `mne_icalabel.label_components`
 
 API
 ~~~
 
-- 
+-
 
 Authors
 ~~~~~~~
 
-* 
+* `Mathieu Scheltienne`_
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_icalabel/label_components.py
+++ b/mne_icalabel/label_components.py
@@ -56,7 +56,7 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA, method: str):
     labels_pred_proba = methods[method](inst, ica)
     labels_pred = np.argmax(labels_pred_proba, axis=1)
     labels = [ICLABEL_NUMERICAL_TO_STRING[label] for label in labels_pred]
-    y_pred_proba = labels_pred_proba[:, labels_pred]
+    y_pred_proba = labels_pred_proba[np.arange(15), labels_pred]
 
     component_dict = {
         "y_pred_proba": y_pred_proba,

--- a/mne_icalabel/tests/test_label_components.py
+++ b/mne_icalabel/tests/test_label_components.py
@@ -22,8 +22,8 @@ def test_label_components():
     """Simple test to check that label_components runs without raising."""
     labels = label_components(raw, ica, method="iclabel")
     assert isinstance(labels, dict)
-    assert labels['y_pred_proba'].ndim == 1
-    assert labels['y_pred_proba'].shape[0] == ica.n_components_
+    assert labels["y_pred_proba"].ndim == 1
+    assert labels["y_pred_proba"].shape[0] == ica.n_components_
 
 
 def test_label_components_with_wrong_arguments():

--- a/mne_icalabel/tests/test_label_components.py
+++ b/mne_icalabel/tests/test_label_components.py
@@ -21,7 +21,9 @@ ica.fit(raw)
 def test_label_components():
     """Simple test to check that label_components runs without raising."""
     labels = label_components(raw, ica, method="iclabel")
-    assert labels is not None
+    assert isinstance(labels, dict)
+    assert labels['y_pred_proba'].ndim == 1
+    assert labels['y_pred_proba'].shape[0] == ica.n_components_
 
 
 def test_label_components_with_wrong_arguments():


### PR DESCRIPTION
Previous selection would return a square matrix, e.g. if 15 components were provided, we would go from `(15, 7)` shape to `(15, 15)` instead of `(15, )`.