### PR TITLE
Add warning if the ICA decomposition provided to ICLabel is not using an extended infomax

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,7 +29,8 @@ Enhancements
 Bug
 ~~~
 
-- Fix shape of ``'y_pred_proba'`` output from `mne_icalabel.label_components`
+- Fix shape of ``'y_pred_proba'`` output from `mne_icalabel.label_components` (:gh:`36`)
+- Add a warning if the ICA decomposition provided does not match the expected decomposition by ``ICLabel`` (:gh:`42`)
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,8 +29,8 @@ Enhancements
 Bug
 ~~~
 
-- Fix shape of ``'y_pred_proba'`` output from `mne_icalabel.label_components` (:gh:`36`)
-- Add a warning if the ICA decomposition provided does not match the expected decomposition by ``ICLabel`` (:gh:`42`)
+- Fix shape of ``'y_pred_proba'`` output from `mne_icalabel.label_components` by `Mathieu Scheltienne`_ (:gh:`36`)
+- Add a warning if the ICA decomposition provided does not match the expected decomposition by ``ICLabel`` `Mathieu Scheltienne`_ (:gh:`42`)
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,7 +30,7 @@ Bug
 ~~~
 
 - Fix shape of ``'y_pred_proba'`` output from `mne_icalabel.label_components` by `Mathieu Scheltienne`_ (:gh:`36`)
-- Add a warning if the ICA decomposition provided does not match the expected decomposition by ``ICLabel`` `Mathieu Scheltienne`_ (:gh:`42`)
+- Add a warning if the ICA decomposition provided does not match the expected decomposition by ``ICLabel``  by `Mathieu Scheltienne`_ (:gh:`42`)
 
 API
 ~~~

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -59,10 +59,10 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
             "and Epochs instances)."
         )
     # confirm that the ICA uses an infomax extended
-    method_ = ica.method not in ('infomax', 'picard')
-    extended_ = 'extended' not in ica.fit_params or ica.fit_params['extended'] is False
-    ortho_ = 'ortho' not in ica.fit_params or ica.fit_params['ortho'] is True
-    ortho_ = ortho_ if ica.method == 'picard' else False
+    method_ = ica.method not in ("infomax", "picard")
+    extended_ = "extended" not in ica.fit_params or ica.fit_params["extended"] is False
+    ortho_ = "ortho" not in ica.fit_params or ica.fit_params["ortho"] is True
+    ortho_ = ortho_ if ica.method == "picard" else False
     if any((method_, extended_, ortho_)):
         warn(
             f"The provided ICA instance was fitted with a '{ica.method}' algorithm. "
@@ -70,7 +70,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
             "extended infomax algorithm, use the 'mne.preprocessing.ICA' instance with the "
             "arguments 'ICA(method='infomax', fit_params=dict(extended=True))' (scikit-learn) or "
             "'ICA(method='picard', fit_params=dict(ortho=False, extended=True))' (python-picard)."
-            )
+        )
 
     icawinv, _ = _retrieve_eeglab_icawinv(ica)
     icaact = _compute_ica_activations(inst, ica)

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -63,7 +63,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     extended_ = 'extended' not in ica.fit_params or ica.fit_params['extended'] is False
     ortho_ = 'ortho' not in ica.fit_params or ica.fit_params['ortho'] is True
     ortho_ = ortho_ if ica.method == 'picard' else False
-    if any(method_, extended_, ortho_):
+    if any((method_, extended_, ortho_)):
         warn(
             f"The provided ICA instance was fitted with a '{ica.method}' algorithm. "
             "ICLabel was designed with extended infomax ICA decompositions. To use the "

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -63,7 +63,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     extended_ = 'extended' not in ica.fit_params or ica.fit_params['extended'] is False
     ortho_ = 'ortho' not in ica.fit_params or ica.fit_params['ortho'] is True
     ortho_ = ortho_ if ica.method == 'picard' else False
-    if method_ or extended_ or ortho_:
+    if any(method_, extended_, ortho_):
         warn(
             f"The provided ICA instance was fitted with a '{ica.method}' algorithm. "
             "ICLabel was designed with extended infomax ICA decompositions. To use the "

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -58,6 +58,19 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
             "bandpass filtered between 1 and 100 Hz (see the 'filter()' method for Raw "
             "and Epochs instances)."
         )
+    # confirm that the ICA uses an infomax extended
+    method_ = ica.method not in ('infomax', 'picard')
+    extended_ = 'extended' not in ica.fit_params or ica.fit_params['extended'] is False
+    ortho_ = 'ortho' not in ica.fit_params or ica.fit_params['ortho'] is True
+    ortho_ = ortho_ if ica.method == 'picard' else False
+    if method_ or extended_ or ortho_:
+        warn(
+            f"The provided ICA instance was fitted with a '{ica.method}' algorithm. "
+            "ICLabel was designed with extended infomax ICA decompositions. To use the "
+            "extended infomax algorithm, use the 'mne.preprocessing.ICA' instance with the "
+            "arguments 'ICA(method='infomax', fit_params=dict(extended=True))' (scikit-learn) or "
+            "'ICA(method='picard', fit_params=dict(ortho=False, extended=True))' (python-picard)."
+            )
 
     icawinv, _ = _retrieve_eeglab_icawinv(ica)
     icaact = _compute_ica_activations(inst, ica)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -4,7 +4,7 @@ from mne import create_info
 from mne.datasets import sample
 from mne.io import RawArray, read_raw
 from mne.preprocessing import ICA
-from mne.utils._logging import logger
+from mne.utils import logger
 
 from mne_icalabel.iclabel import iclabel_label_components
 

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -30,7 +30,9 @@ def test_warnings():
     """Test warnings issued when the raw|epochs|ica instance are not using the
     same algorithm/reference/filters as ICLabel."""
     data = np.random.randint(low=1, high=10, size=(6, 10000)) / 1000
-    raw = RawArray(data, create_info(["Fpz", "CPz", "Oz", "Fp1", "Fp2", "Cz"], sfreq=500, ch_types="eeg"))
+    raw = RawArray(
+        data, create_info(["Fpz", "CPz", "Oz", "Fp1", "Fp2", "Cz"], sfreq=500, ch_types="eeg")
+    )
     raw.set_montage("standard_1020")
     raw.filter(1.0, None)
 

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -1,7 +1,9 @@
 import pytest
+from mne import create_info
 from mne.datasets import sample
-from mne.io import read_raw
+from mne.io import read_raw, RawArray
 from mne.preprocessing import ICA
+import numpy as np
 
 from mne_icalabel.iclabel import iclabel_label_components
 
@@ -22,3 +24,36 @@ def test_label_components():
     """Simple test to check that label_components runs without raising."""
     labels = iclabel_label_components(raw, ica)
     assert labels.shape == (ica.n_components_, 7)
+
+
+def test_warnings():
+    """Test warnings issued when the raw|epochs|ica instance are not using the
+    same algorithm/reference/filters as ICLabel."""
+    data = np.random.randint(low=1, high=10, size=(3, 5000))
+    raw = RawArray(data, create_info(['Fpz', 'CPz', 'Oz'], sfreq=500, ch_types='eeg'))
+    raw.set_montage('standard_1020')
+    raw.filter(1., None)
+
+    # wrong raw, correct ica
+    ica = ICA(n_components=3, method='infomax', fit_params=dict(extended=True))
+    ica.fit(raw)
+    with pytest.warns(RuntimeWarning, match="common average reference"), pytest.warns(RuntimeWarning, match="not filtered between 1 and 100 Hz"):
+        iclabel_label_components(raw, ica)
+    # correct raw, wrong ica
+    raw.filter(1., 100.)
+    raw.set_eeg_reference('average')
+    # infomax
+    ica = ICA(n_components=3, method='infomax', fit_params=dict(extended=False))
+    ica.fit(raw)
+    with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
+        iclabel_label_components(raw, ica)
+    # fastica
+    ica = ICA(n_components=3)
+    ica.fit(raw)
+    with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
+        iclabel_label_components(raw, ica)
+    # picard
+    ica = ICA(n_components=3, method='picard')
+    ica.fit(raw)
+    with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
+        iclabel_label_components(raw, ica)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -13,7 +13,7 @@ raw.load_data()
 raw.filter(l_freq=1.0, h_freq=100.0)
 raw.set_eeg_reference("average")
 # fit ICA
-ica = ICA(n_components=15, method="picard")
+ica = ICA(n_components=5, method="picard")
 ica.fit(raw)
 
 
@@ -21,4 +21,4 @@ ica.fit(raw)
 def test_label_components():
     """Simple test to check that label_components runs without raising."""
     labels = iclabel_label_components(raw, ica)
-    assert labels is not None
+    assert labels.shape == (ica.n_components_, 7)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -4,7 +4,6 @@ from mne import create_info
 from mne.datasets import sample
 from mne.io import RawArray, read_raw
 from mne.preprocessing import ICA
-from mne.utils._logging import logger
 
 from mne_icalabel.iclabel import iclabel_label_components
 
@@ -18,8 +17,6 @@ raw.set_eeg_reference("average")
 # fit ICA
 ica = ICA(n_components=5, method="picard")
 ica.fit(raw)
-
-logger.propagate = True
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -15,7 +15,7 @@ raw.load_data()
 raw.filter(l_freq=1.0, h_freq=100.0)
 raw.set_eeg_reference("average")
 # fit ICA
-ica = ICA(n_components=5, method="picard")
+ica = ICA(n_components=5, method="picard", random_state=101)
 ica.fit(raw)
 
 
@@ -37,7 +37,7 @@ def test_warnings():
     raw.filter(1.0, None)
 
     # wrong raw, correct ica
-    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=True))
+    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=True), random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="common average reference"):
         iclabel_label_components(raw, ica)
@@ -47,17 +47,17 @@ def test_warnings():
     raw.filter(1.0, 100.0)
     raw.set_eeg_reference("average")
     # infomax
-    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=False))
+    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=False), random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # fastica
-    ica = ICA(n_components=4, tol=1e-2)
+    ica = ICA(n_components=4, fit_params=dict(tol=1e-2), random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # picard
-    ica = ICA(n_components=4, method="picard")
+    ica = ICA(n_components=4, method="picard", random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -1,9 +1,9 @@
+import numpy as np
 import pytest
 from mne import create_info
 from mne.datasets import sample
-from mne.io import read_raw, RawArray
+from mne.io import RawArray, read_raw
 from mne.preprocessing import ICA
-import numpy as np
 
 from mne_icalabel.iclabel import iclabel_label_components
 
@@ -30,20 +30,22 @@ def test_warnings():
     """Test warnings issued when the raw|epochs|ica instance are not using the
     same algorithm/reference/filters as ICLabel."""
     data = np.random.randint(low=1, high=10, size=(3, 5000))
-    raw = RawArray(data, create_info(['Fpz', 'CPz', 'Oz'], sfreq=500, ch_types='eeg'))
-    raw.set_montage('standard_1020')
-    raw.filter(1., None)
+    raw = RawArray(data, create_info(["Fpz", "CPz", "Oz"], sfreq=500, ch_types="eeg"))
+    raw.set_montage("standard_1020")
+    raw.filter(1.0, None)
 
     # wrong raw, correct ica
-    ica = ICA(n_components=3, method='infomax', fit_params=dict(extended=True))
+    ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=True))
     ica.fit(raw)
-    with pytest.warns(RuntimeWarning, match="common average reference"), pytest.warns(RuntimeWarning, match="not filtered between 1 and 100 Hz"):
+    with pytest.warns(RuntimeWarning, match="common average reference"), pytest.warns(
+        RuntimeWarning, match="not filtered between 1 and 100 Hz"
+    ):
         iclabel_label_components(raw, ica)
     # correct raw, wrong ica
-    raw.filter(1., 100.)
-    raw.set_eeg_reference('average')
+    raw.filter(1.0, 100.0)
+    raw.set_eeg_reference("average")
     # infomax
-    ica = ICA(n_components=3, method='infomax', fit_params=dict(extended=False))
+    ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=False))
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
@@ -53,7 +55,7 @@ def test_warnings():
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # picard
-    ica = ICA(n_components=3, method='picard')
+    ica = ICA(n_components=3, method="picard")
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -52,7 +52,7 @@ def test_warnings():
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # fastica
-    ica = ICA(n_components=4)
+    ica = ICA(n_components=4, tol=1e-2)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -41,7 +41,7 @@ def test_warnings():
         RuntimeWarning, match="not filtered between 1 and 100 Hz"
     ):
         iclabel_label_components(raw, ica)
-    # correct raw, wrong ica
+
     raw.filter(1.0, 100.0)
     raw.set_eeg_reference("average")
     # infomax

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -4,7 +4,7 @@ from mne import create_info
 from mne.datasets import sample
 from mne.io import RawArray, read_raw
 from mne.preprocessing import ICA
-from mne.utils import logger
+from mne.utils._logging import logger
 
 from mne_icalabel.iclabel import iclabel_label_components
 

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -4,6 +4,7 @@ from mne import create_info
 from mne.datasets import sample
 from mne.io import RawArray, read_raw
 from mne.preprocessing import ICA
+from mne.utils._logging import logger
 
 from mne_icalabel.iclabel import iclabel_label_components
 
@@ -17,6 +18,8 @@ raw.set_eeg_reference("average")
 # fit ICA
 ica = ICA(n_components=5, method="picard")
 ica.fit(raw)
+
+logger.propagate = True
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -29,33 +29,33 @@ def test_label_components():
 def test_warnings():
     """Test warnings issued when the raw|epochs|ica instance are not using the
     same algorithm/reference/filters as ICLabel."""
-    data = np.random.randint(low=1, high=10, size=(3, 5000))
-    raw = RawArray(data, create_info(["Fpz", "CPz", "Oz"], sfreq=500, ch_types="eeg"))
+    data = np.random.randint(low=1, high=10, size=(6, 10000)) / 1000
+    raw = RawArray(data, create_info(["Fpz", "CPz", "Oz", "Fp1", "Fp2", "Cz"], sfreq=500, ch_types="eeg"))
     raw.set_montage("standard_1020")
     raw.filter(1.0, None)
 
     # wrong raw, correct ica
-    ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=True))
+    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=True))
     ica.fit(raw)
-    with pytest.warns(RuntimeWarning, match="common average reference"), pytest.warns(
-        RuntimeWarning, match="not filtered between 1 and 100 Hz"
-    ):
+    with pytest.warns(RuntimeWarning, match="common average reference"):
+        iclabel_label_components(raw, ica)
+    with pytest.warns(RuntimeWarning, match="not filtered between 1 and 100 Hz"):
         iclabel_label_components(raw, ica)
 
     raw.filter(1.0, 100.0)
     raw.set_eeg_reference("average")
     # infomax
-    ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=False))
+    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=False))
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # fastica
-    ica = ICA(n_components=3)
+    ica = ICA(n_components=4)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # picard
-    ica = ICA(n_components=3, method="picard")
+    ica = ICA(n_components=4, method="picard")
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)


### PR DESCRIPTION
As pointed out by @jacobf18 in https://github.com/mne-tools/mne-icalabel/pull/40#issuecomment-1120450589
I added a warning if the ICA provided is not using an extended infomax + test for this warning and the 2 previously added warnings if the raw|epochs instance was not filtered between [1, 100] Hz or referenced to a common average.