### PR TITLE
Improve and speed-up test for warnings in ICLabel

### DIFF
--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -32,14 +32,14 @@ def test_warnings():
     times = np.linspace(0, 5, 2000)
     signals = np.array([np.sin(2 * np.pi * k * times) for k in (7, 22, 37, 7, 22, 37)])
     coeffs = np.random.rand(6, 6)
-    data = np.dot(coeffs, signals) + np.random.normal(0, .1, signals.shape)
+    data = np.dot(coeffs, signals) + np.random.normal(0, 0.1, signals.shape)
 
     raw = RawArray(
         data, create_info(["Fpz", "Cz", "CPz", "Oz", "M1", "M2"], sfreq=400, ch_types="eeg")
     )
     raw.set_montage("standard_1020")
     with raw.info._unlock():
-        raw.info['highpass'] = 1.
+        raw.info["highpass"] = 1.0
 
     # wrong raw, correct ica
     ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=True), random_state=101)
@@ -50,7 +50,7 @@ def test_warnings():
         iclabel_label_components(raw, ica)
 
     with raw.info._unlock():
-        raw.info['lowpass'] = 100.
+        raw.info["lowpass"] = 100.0
     raw.set_eeg_reference("average")
     # infomax
     ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=False), random_state=101)

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -30,9 +30,9 @@ def test_warnings():
     """Test warnings issued when the raw|epochs|ica instance are not using the
     same algorithm/reference/filters as ICLabel."""
     times = np.linspace(0, 5, 2000)
-    signals = np.array([np.sin(2 * np.pi * k * times) for k in (7, 22, 37, 7, 22, 37)])
-    coeffs = np.random.rand(6, 6)
-    data = np.dot(coeffs, signals) + np.random.normal(0, 0.1, signals.shape)
+    signals = np.array([np.sin(2 * np.pi * k * times) for k in (7, 22, 37)])
+    coeffs = np.random.rand(6, 3)
+    data = np.dot(coeffs, signals) + np.random.normal(0, 0.1, (coeffs.shape[0], times.size))
 
     raw = RawArray(
         data, create_info(["Fpz", "Cz", "CPz", "Oz", "M1", "M2"], sfreq=400, ch_types="eeg")

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -29,35 +29,41 @@ def test_label_components():
 def test_warnings():
     """Test warnings issued when the raw|epochs|ica instance are not using the
     same algorithm/reference/filters as ICLabel."""
-    data = np.random.randint(low=1, high=10, size=(6, 10000)) / 1000
+    times = np.linspace(0, 5, 2000)
+    signals = np.array([np.sin(2 * np.pi * k * times) for k in (7, 22, 37, 7, 22, 37)])
+    coeffs = np.random.rand(6, 6)
+    data = np.dot(coeffs, signals) + np.random.normal(0, .1, signals.shape)
+
     raw = RawArray(
-        data, create_info(["Fpz", "CPz", "Oz", "Fp1", "Fp2", "Cz"], sfreq=500, ch_types="eeg")
+        data, create_info(["Fpz", "Cz", "CPz", "Oz", "M1", "M2"], sfreq=400, ch_types="eeg")
     )
     raw.set_montage("standard_1020")
-    raw.filter(1.0, None)
+    with raw.info._unlock():
+        raw.info['highpass'] = 1.
 
     # wrong raw, correct ica
-    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=True), random_state=101)
+    ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=True), random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="common average reference"):
         iclabel_label_components(raw, ica)
     with pytest.warns(RuntimeWarning, match="not filtered between 1 and 100 Hz"):
         iclabel_label_components(raw, ica)
 
-    raw.filter(1.0, 100.0)
+    with raw.info._unlock():
+        raw.info['lowpass'] = 100.
     raw.set_eeg_reference("average")
     # infomax
-    ica = ICA(n_components=4, method="infomax", fit_params=dict(extended=False), random_state=101)
+    ica = ICA(n_components=3, method="infomax", fit_params=dict(extended=False), random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # fastica
-    ica = ICA(n_components=4, fit_params=dict(tol=1e-2), random_state=101)
+    ica = ICA(n_components=3, fit_params=dict(tol=1e-2), random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)
     # picard
-    ica = ICA(n_components=4, method="picard", random_state=101)
+    ica = ICA(n_components=3, method="picard", random_state=101)
     ica.fit(raw)
     with pytest.warns(RuntimeWarning, match="designed with extended infomax ICA"):
         iclabel_label_components(raw, ica)


### PR DESCRIPTION
I replaced the random data array with 3 sources measured across 6 channels.
It should prevent convergence issues and be faster.