### PR TITLE
Ignore RuntimeWarnings issued by the grid interpolation for ICLabel topographic feature

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,12 +24,12 @@ Version 0.3 (Unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
-- 
+-
 
 Bug
 ~~~
 
-- 
+- Ignore the ``RuntimeWarning`` issued by the grid inteprolation for ICLabel topographic feature by `Mathieu Scheltienne`_ (:gh:`69`)
 
 API
 ~~~
@@ -39,7 +39,7 @@ API
 Authors
 ~~~~~~~
 
-* 
+*
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_icalabel/iclabel/tests/test_features.py
+++ b/mne_icalabel/iclabel/tests/test_features.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -86,7 +87,9 @@ def test_get_features_from_precomputed_ica(file, psd_constant_file, eeglab_featu
     ica = read_ica_eeglab(file)
 
     # Retrieve topo and autocorr
-    topo, _, autocorr = get_iclabel_features(inst, ica)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        topo, _, autocorr = get_iclabel_features(inst, ica)
 
     # Build PSD feature manually to match the subset
     # retrieve activation

--- a/mne_icalabel/iclabel/tests/test_features.py
+++ b/mne_icalabel/iclabel/tests/test_features.py
@@ -71,7 +71,6 @@ kwargs = {"raw": dict(preload=True), "epo": dict()}
 
 
 # ----------------------------------------------------------------------------
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize(
     "file, psd_constant_file, eeglab_feature_file",
     [
@@ -147,7 +146,6 @@ def test_compute_ica_activations(file, eeglab_result_file):
 
 
 # ----------------------------------------------------------------------------
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize(
     "file, eeglab_result_file",
     [(raw_eeglab_path, raw_topo1_path), (epo_eeglab_path, epo_topo1_path)],
@@ -172,7 +170,6 @@ def test_topoplotFast(file, eeglab_result_file):
     assert np.allclose(topo1, topo1_eeglab, equal_nan=True)
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize(
     "file, eeglab_result_file",
     [

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -12,7 +12,9 @@ raw = read_raw(directory / "sample_audvis_trunc_raw.fif", preload=False)
 raw.pick_types(eeg=True, exclude=[])
 raw.load_data()
 # preprocess
-raw.filter(l_freq=1.0, h_freq=100.0)
+with raw.info._unlock():  # fake filtering, testing dataset is filtered between [0.1, 80] Hz
+    raw.info["highpass"] = 1.
+    raw.info["lowpass"] = 100.
 raw.set_eeg_reference("average")
 
 

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -13,8 +13,8 @@ raw.pick_types(eeg=True, exclude=[])
 raw.load_data()
 # preprocess
 with raw.info._unlock():  # fake filtering, testing dataset is filtered between [0.1, 80] Hz
-    raw.info["highpass"] = 1.
-    raw.info["lowpass"] = 100.
+    raw.info["highpass"] = 1.0
+    raw.info["lowpass"] = 100.0
 raw.set_eeg_reference("average")
 
 

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -16,7 +16,6 @@ raw.filter(l_freq=1.0, h_freq=100.0)
 raw.set_eeg_reference("average")
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize(
     "inst, exclude",
     (

--- a/mne_icalabel/iclabel/tests/test_utils.py
+++ b/mne_icalabel/iclabel/tests/test_utils.py
@@ -48,8 +48,6 @@ def test_loc(file, eeglab_result_file):
     assert np.allclose(th, eeglab_th, atol=1e-8)
 
 
-# TODO: Warnings should be fixed at some point.
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("file", (gdatav4_raw_path, gdatav4_epo_path))
 def test_gdatav4(file):
     """Test grid data interpolation."""

--- a/mne_icalabel/iclabel/utils.py
+++ b/mne_icalabel/iclabel/utils.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Tuple
 
 import numpy as np
@@ -135,8 +136,15 @@ def _gdatav4(
 
     # Determine distances between points
     d = np.abs(np.subtract.outer(xy, xy))
-    # % Determine weights for interpolation
-    g = np.square(d) * (np.log(d) - 1)  # % Green's function.
+    # Determine weights for interpolation
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="divide by zero encountered in log", category=RuntimeWarning
+        )
+        warnings.filterwarnings(
+            "ignore", message="invalid value encountered in multiply", category=RuntimeWarning
+        )
+        g = np.square(d) * (np.log(d) - 1)  # Green's function.
     # Fixup value of Green's function along diagonal
     np.fill_diagonal(g, 0)
     weights = np.linalg.lstsq(g, v, rcond=-1)[0]

--- a/mne_icalabel/tests/test_label_components.py
+++ b/mne_icalabel/tests/test_label_components.py
@@ -10,14 +10,16 @@ raw = read_raw(directory / "sample_audvis_trunc_raw.fif", preload=False)
 raw.pick_types(eeg=True, exclude="bads")
 raw.load_data()
 # preprocess
-raw.filter(l_freq=1.0, h_freq=100.0)
+with raw.info._unlock():  # fake filtering, testing dataset is filtered between [0.1, 80] Hz
+    raw.info["highpass"] = 1.
+    raw.info["lowpass"] = 100.
 raw.set_eeg_reference("average")
 
 
 @pytest.mark.parametrize("n_components", (5, 15))
 def test_label_components(n_components):
     """Simple test to check that label_components runs without raising."""
-    ica = ICA(n_components=n_components, method="picard")
+    ica = ICA(n_components=n_components, method="infomax", fit_params=dict(extended=True))
     ica.fit(raw)
     labels = label_components(raw, ica, method="iclabel")
     assert isinstance(labels, dict)

--- a/mne_icalabel/tests/test_label_components.py
+++ b/mne_icalabel/tests/test_label_components.py
@@ -11,8 +11,8 @@ raw.pick_types(eeg=True, exclude="bads")
 raw.load_data()
 # preprocess
 with raw.info._unlock():  # fake filtering, testing dataset is filtered between [0.1, 80] Hz
-    raw.info["highpass"] = 1.
-    raw.info["lowpass"] = 100.
+    raw.info["highpass"] = 1.0
+    raw.info["lowpass"] = 100.0
 raw.set_eeg_reference("average")
 
 

--- a/mne_icalabel/tests/test_label_components.py
+++ b/mne_icalabel/tests/test_label_components.py
@@ -14,7 +14,6 @@ raw.filter(l_freq=1.0, h_freq=100.0)
 raw.set_eeg_reference("average")
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("n_components", (5, 15))
 def test_label_components(n_components):
     """Simple test to check that label_components runs without raising."""


### PR DESCRIPTION
Fixes the remaining RuntimeWarnings that were issued by the grid interpolation.
Originally reported here: https://mne.discourse.group/t/mne-icalabel-package/5257/5
Fixes the TODO item here: https://github.com/mne-tools/mne-icalabel/blob/15679f1adf9a8c39d3fc208e907f4f3b02a24462/mne_icalabel/iclabel/tests/test_utils.py#L51-L52