### PR TITLE
[ENH] get_topomap_array is now a private method 

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -55,7 +55,6 @@ Contains functions to extract features from `~mne.preprocessing.ICA` instance an
 .. autosummary::
    :toctree: generated/
 
-   get_topomap_array
    get_topomaps
 
 Annotating Components

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,16 +213,16 @@ html_context = {
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
+    'joblib': ('https://joblib.readthedocs.io/en/latest', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
     'mne': ('https://mne.tools/dev', None),
     'numpy': ('https://numpy.org/devdocs', None),
-    'scipy': ('https://scipy.github.io/devdocs', None),
-    'matplotlib': ('https://matplotlib.org/stable', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/dev', None),
-    'sklearn': ('https://scikit-learn.org/stable', None),
-    'joblib': ('https://joblib.readthedocs.io/en/latest', None),
-    "torch": ("https://pytorch.org/docs/stable", None),
     'pooch': ('https://www.fatiando.org/pooch/latest/', None),
+    'python': ('https://docs.python.org/3', None),
+    'scipy': ('https://scipy.github.io/devdocs', None),
+    'sklearn': ('https://scikit-learn.org/stable', None),
+    "torch": ("https://pytorch.org/docs/stable", None),
 }
 intersphinx_timeout = 5
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,7 +34,7 @@ Bug
 API
 ~~~
 
-- Add topographic feature using MNE with `~mne_icalabel.features.get_topomap_array` and `~mne_icalabel.features.get_topomaps` by `Anand Saini`_ and `Mathieu Scheltienne`_ (:gh:`71`)
+- Add topographic feature using MNE with `~mne_icalabel.features.get_topomaps` by `Anand Saini`_ and `Mathieu Scheltienne`_ (:gh:`71`)
 
 Authors
 ~~~~~~~

--- a/mne_icalabel/features/__init__.py
+++ b/mne_icalabel/features/__init__.py
@@ -1,3 +1,3 @@
 """Features for the ICLabel"""
 
-from .topomap import get_topomap_array, get_topomaps  # noqa: F401
+from .topomap import get_topomaps  # noqa: F401

--- a/mne_icalabel/features/tests/test_topomap.py
+++ b/mne_icalabel/features/tests/test_topomap.py
@@ -4,7 +4,8 @@ from mne.datasets import testing
 from mne.io import read_raw
 from mne.preprocessing import ICA
 
-from mne_icalabel.features import get_topomap_array, get_topomaps
+from mne_icalabel.features import get_topomaps
+from mne_icalabel.features.topomap import _get_topomap_array
 
 directory = testing.data_path() / "MEG" / "sample"
 raw = read_raw(directory / "sample_audvis_trunc_raw.fif", preload=False)
@@ -22,7 +23,7 @@ def test_topomap_defaults():
 
     # test single topo with fake data
     data = np.random.randint(1, 10, len(raw.ch_names))
-    topomap = get_topomap_array(data, raw.info)
+    topomap = _get_topomap_array(data, raw.info)
     assert isinstance(topomap, np.ndarray)
     assert topomap.shape == (64, 64)
 
@@ -43,7 +44,7 @@ def test_topomap_arguments(picks, res):
     assert topomaps.shape == (n_components, res, res)
 
     data = np.random.randint(1, 10, len(raw.ch_names))
-    topomap = get_topomap_array(data, raw.info, res=res)
+    topomap = _get_topomap_array(data, raw.info, res=res)
     assert isinstance(topomap, np.ndarray)
     assert topomap.shape == (res, res)
 

--- a/mne_icalabel/features/topomap.py
+++ b/mne_icalabel/features/topomap.py
@@ -49,7 +49,7 @@ def get_topomaps(
     topomaps = np.zeros((len(picks), res, res))
     for i, component in enumerate(picks):
         topo = np.flipud(
-            get_topomap_array(
+            _get_topomap_array(
                 data[component, :], ica.info, res, outlines, image_interp, border, extrapolate
             )
         )
@@ -61,7 +61,7 @@ def get_topomaps(
 
 
 @fill_doc
-def get_topomap_array(
+def _get_topomap_array(
     data: NDArray[float],
     pos: Info,
     res: int = 64,


### PR DESCRIPTION
The goal is to support only MNE instances in the public API.
The changes were implemented in #73, I am moving them here to start looking into the tests coverage in #93.