### PR TITLE
Add bibclean static-check/auto-format for references.bib

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           path: "./mne_icalabel"
           mypy_flags: "--config-file pyproject.toml"
+      - name: Run bibclean
+        run: bibclean-check doc/references.bib
 
   build:
     timeout-minutes: 10

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,29 +1,21 @@
-% Encoding: UTF-8
-%
-% If available, include a DOI (preferred) *or* a URL for a given reference, but
-% not both, as the DOI turns into a link which is redundant with the URL.
-
-@inproceedings{WinklerEtAl2015,
-  address   = {{Milan}},
-  author    = {Winkler, Irene and Debener, Stefan and Müller, Klaus-Robert and Tangermann, Michael},
-  booktitle = {Proceedings of {{EMBC}}-2015},
-  doi       = {10.1109/EMBC.2015.7319296},
-  isbn      = {978-1-4244-9271-8},
-  pages     = {4101-4105},
-  publisher = {{IEEE}},
-  title     = {On the Influence of High-Pass Filtering on {{ICA}}-Based Artifact Reduction in {{EEG}}-{{ERP}}},
-  year      = {2015}
+@article{iclabel2019,
+ author = {Luca Pion-Tonachini and Ken Kreutz-Delgado and Scott Makeig},
+ doi = {https://doi.org/10.1016/j.neuroimage.2019.05.026},
+ journal = {NeuroImage},
+ pages = {181-197},
+ title = {ICLabel: An automated electroencephalographic independent component classifier, dataset, and website},
+ volume = {198},
+ year = {2019}
 }
 
-@article{iclabel2019,
-  title    = {ICLabel: An automated electroencephalographic independent component classifier, dataset, and website},
-  journal  = {NeuroImage},
-  volume   = {198},
-  pages    = {181-197},
-  year     = {2019},
-  issn     = {1053-8119},
-  doi      = {https://doi.org/10.1016/j.neuroimage.2019.05.026},
-  author   = {Luca Pion-Tonachini and Ken Kreutz-Delgado and Scott Makeig},
-  keywords = {EEG, ICA, Classification, Crowdsourcing},
-  abstract = {The electroencephalogram (EEG) provides a non-invasive, minimally restrictive, and relatively low-cost measure of mesoscale brain dynamics with high temporal resolution. Although signals recorded in parallel by multiple, near-adjacent EEG scalp electrode channels are highly-correlated and combine signals from many different sources, biological and non-biological, independent component analysis (ICA) has been shown to isolate the various source generator processes underlying those recordings. Independent components (IC) found by ICA decomposition can be manually inspected, selected, and interpreted, but doing so requires both time and practice as ICs have no order or intrinsic interpretations and therefore require further study of their properties. Alternatively, sufficiently-accurate automated IC classifiers can be used to classify ICs into broad source categories, speeding the analysis of EEG studies with many subjects and enabling the use of ICA decomposition in near-real-time applications. While many such classifiers have been proposed recently, this work presents the ICLabel project comprised of (1) the ICLabel dataset containing spatiotemporal measures for over 200,000 ICs from more than 6000 EEG recordings and matching component labels for over 6000 of those ICs, all using common average reference, (2) the ICLabel website for collecting crowdsourced IC labels and educating EEG researchers and practitioners about IC interpretation, and (3) the automated ICLabel classifier, freely available for MATLAB. The ICLabel classifier improves upon existing methods in two ways: by improving the accuracy of the computed label estimates and by enhancing its computational efficiency. The classifier outperforms or performs comparably to the previous best publicly available automated IC component classification method for all measured IC categories while computing those labels ten times faster than that classifier as shown by a systematic comparison against other publicly available EEG IC classifiers.}
+@inproceedings{WinklerEtAl2015,
+ address = {{Milan}},
+ author = {Winkler, Irene and Debener, Stefan and Müller, Klaus-Robert and Tangermann, Michael},
+ booktitle = {Proceedings of {{EMBC}}-2015},
+ doi = {10.1109/EMBC.2015.7319296},
+ isbn = {978-1-4244-9271-8},
+ pages = {4101-4105},
+ publisher = {{IEEE}},
+ title = {On the Influence of High-Pass Filtering on {{ICA}}-Based Artifact Reduction in {{EEG}}-{{ERP}}},
+ year = {2015}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ ica = [
     'scikit-learn',
 ]
 style = [
+    'bibclean',
     'black',
     'codespell',
     'isort',


### PR DESCRIPTION
@adam2392 I was tired of long/messy `references.bib` provided to `sphinxcontrib-bibtex` in doc-builds, so I made this util a few days ago. It's basically a simpler equivalent of `black` / `isort` for BibTex files.

It has an auto-format command (`bibclean file.bib`) and a check command (`bibclean-check file.bib`, added to the style CI). Behavior can be configured in `pyproject.toml`. The check makes sure:
- There are no duplicates (checked both by entry-key and by `hash((author, title, year))`)
- That `bibclean` was run -> i.e. the file is correctly formatted: sorted by cite-key, fields alphabetically sorted, DOI or URL (not both, DOI preferred), and irrelevant fields have been removed.

Not that big of a deal on this project with only 2 elements in `references.bib`, but doesn't hurt to add it ;)

Merge if happy :)