### PR TITLE
[MNT] Fix intersphinx for numpy/scipy

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - "**.py"
   workflow_dispatch:
+  schedule:
+  - cron: '0 8 * * 1'
 
 jobs:
   style:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -193,11 +193,11 @@ intersphinx_mapping = {
     "joblib": ("https://joblib.readthedocs.io/en/latest", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "mne": ("https://mne.tools/dev", None),
-    "numpy": ("https://numpy.org/devdocs", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/dev", None),
     "pooch": ("https://www.fatiando.org/pooch/latest/", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://scipy.github.io/devdocs", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "sklearn": ("https://scikit-learn.org/stable", None),
     "torch": ("https://pytorch.org/docs/stable", None),
 }

--- a/mne_icalabel/features/tests/test_topomap.py
+++ b/mne_icalabel/features/tests/test_topomap.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 from mne.datasets import testing
@@ -92,7 +94,9 @@ def test_invalid_arguments():
     with pytest.raises(RuntimeError, match="The provided ICA instance was not fitted."):
         get_topomaps(ICA(n_components=5, method="picard"))
 
-    with pytest.raises(TypeError, match="picks must be a list of int or list of str"):
+    with pytest.raises(
+        TypeError, match=re.escape("picks must be a list of int (indices) or list of str (names).")
+    ):
         get_topomaps(ica, picks=101 + 101j)
     with pytest.raises(TypeError, match="Strings are not supported."):
         get_topomaps(ica, picks="101")


### PR DESCRIPTION
The numpy link to the `dev` doc is not valid anymore. 
I replaced both links for numpy and scipy with the current valid ones for the `stable` documentation.