### PR TITLE
Added ONNX support

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          skip: "./.git,./build,./.mypy_cache,./.pytest_cache,./mne_iclabel/iclabel/assets"
+          skip: "./.git,./build,./.mypy_cache,./.pytest_cache,./mne_icalabel/iclabel/assets"
           ignore_words_file: ./.codespellignore
       - name: Run pydocstyle
         run: pydocstyle .

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          skip: "./.git,./build,./.mypy_cache,./.pytest_cache"
+          skip: "./.git,./build,./.mypy_cache,./.pytest_cache,./mne_iclabel/iclabel/assets"
           ignore_words_file: ./.codespellignore
       - name: Run pydocstyle
         run: pydocstyle .

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PYTHON ?= python
 PYTESTS ?= py.test
 CTAGS ?= ctags
-CODESPELL_SKIPS ?= "*.fif,*.eve,*.gz,*.tgz,*.zip,*.mat,*.stc,*.label,*.w,*.bz2,*.annot,*.sulc,*.log,*.local-copy,*.orig_avg,*.inflated_avg,*.gii,*.pyc,*.doctree,*.pickle,*.inv,*.png,*.edf,*.touch,*.thickness,*.nofix,*.volume,*.defect_borders,*.mgh,lh.*,rh.*,COR-*,FreeSurferColorLUT.txt,*.examples,.xdebug_mris_calc,bad.segments,BadChannels,empty_file,*.orig,*.js,*.map,*.ipynb,searchindex.dat,plot_*.rst,*.rst.txt,*.html,gdf_encodes.txt,*.svg,*.css"
+CODESPELL_SKIPS ?= "*.fif,*.eve,*.gz,*.tgz,*.zip,*.mat,*.stc,*.label,*.w,*.bz2,*.annot,*.sulc,*.log,*.local-copy,*.orig_avg,*.inflated_avg,*.gii,*.pyc,*.doctree,*.pickle,*.inv,*.png,*.edf,*.touch,*.thickness,*.nofix,*.volume,*.defect_borders,*.mgh,lh.*,rh.*,COR-*,FreeSurferColorLUT.txt,*.examples,.xdebug_mris_calc,bad.segments,BadChannels,empty_file,*.orig,*.js,*.map,*.ipynb,searchindex.dat,plot_*.rst,*.rst.txt,*.html,gdf_encodes.txt,*.svg,*.css,*.onnx"
 CODESPELL_DIRS ?= mne_icalabel/ doc/ examples/
 all: clean inplace test test-doc
 

--- a/mne_icalabel/iclabel/network.py
+++ b/mne_icalabel/iclabel/network.py
@@ -196,9 +196,7 @@ def _format_input(topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike):
     return formatted_topo, formatted_psd, formatted_autocorr
 
 
-def _format_input_for_torch(
-    topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+def _format_input_for_torch(topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike):
     """Format the features to the correct shape and type for pytorch."""
     topo = np.transpose(topo, (3, 2, 0, 1))
     psd = np.transpose(psd, (3, 2, 0, 1))
@@ -211,9 +209,7 @@ def _format_input_for_torch(
     return topo, psd, autocorr
 
 
-def _format_input_for_onnx(
-    topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike
-) -> tuple[ArrayLike, ArrayLike, ArrayLike]:
+def _format_input_for_onnx(topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike):
     """Format the features to the correct shape and type for ONNX."""
     topo = np.transpose(topo, (3, 2, 0, 1)).astype(np.float32)
     psd = np.transpose(psd, (3, 2, 0, 1)).astype(np.float32)

--- a/mne_icalabel/iclabel/network.py
+++ b/mne_icalabel/iclabel/network.py
@@ -4,10 +4,10 @@ except ImportError:
     from importlib_resources import files  # type: ignore
 
 import numpy as np
+import onnxruntime as ort
 import torch
 import torch.nn as nn
 from numpy.typing import ArrayLike
-import onnxruntime as ort
 
 
 class _ICLabelNetImg(nn.Module):

--- a/mne_icalabel/iclabel/network.py
+++ b/mne_icalabel/iclabel/network.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from numpy.typing import ArrayLike
+import onnxruntime as ort
 
 
 class _ICLabelNetImg(nn.Module):
@@ -195,7 +196,9 @@ def _format_input(topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike):
     return formatted_topo, formatted_psd, formatted_autocorr
 
 
-def _format_input_for_torch(topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike):
+def _format_input_for_torch(
+    topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Format the features to the correct shape and type for pytorch."""
     topo = np.transpose(topo, (3, 2, 0, 1))
     psd = np.transpose(psd, (3, 2, 0, 1))
@@ -208,7 +211,18 @@ def _format_input_for_torch(topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike
     return topo, psd, autocorr
 
 
-def run_iclabel(images: ArrayLike, psds: ArrayLike, autocorr: ArrayLike):
+def _format_input_for_onnx(
+    topo: ArrayLike, psd: ArrayLike, autocorr: ArrayLike
+) -> tuple[ArrayLike, ArrayLike, ArrayLike]:
+    """Format the features to the correct shape and type for ONNX."""
+    topo = np.transpose(topo, (3, 2, 0, 1)).astype(np.float32)
+    psd = np.transpose(psd, (3, 2, 0, 1)).astype(np.float32)
+    autocorr = np.transpose(autocorr, (3, 2, 0, 1)).astype(np.float32)
+
+    return topo, psd, autocorr
+
+
+def run_iclabel(images: ArrayLike, psds: ArrayLike, autocorr: ArrayLike, library: str = "pytorch"):
     """Run the ICLabel network on the provided set of features.
 
     The features are un-formatted and are as-returned by
@@ -230,16 +244,37 @@ def run_iclabel(images: ArrayLike, psds: ArrayLike, autocorr: ArrayLike):
         Columns are ordered with ``'Brain'``, ``'Muscle'``, ``'Eye'``,
         ``'Heart'``, ``'Line Noise'``, ``'Channel Noise'``, and ``'Other'``.
     """
-    ica_network_file = files("mne_icalabel.iclabel").joinpath("assets/iclabelNet.pt")
+    if library == "pytorch":
+        ica_network_file = files("mne_icalabel.iclabel").joinpath("assets/iclabelNet.pt")
 
-    # Get network and load weights
-    iclabel_net = ICLabelNet()
-    iclabel_net.load_state_dict(torch.load(ica_network_file))
+        # Get network and load weights
+        iclabel_net = ICLabelNet()
+        iclabel_net.load_state_dict(torch.load(ica_network_file))
 
-    # Format input and get labels
-    labels = iclabel_net(*_format_input_for_torch(*_format_input(images, psds, autocorr)))
-    labels = labels.detach().numpy()
+        # Format input and get labels
+        labels = iclabel_net(*_format_input_for_torch(*_format_input(images, psds, autocorr)))
+        labels = labels.detach().numpy()
 
-    # outputs are ordered as in
-    # https://github.com/sccn/ICLabel/blob/e8abc99e0c371ff49eff115cf7955fafc7f7969a/iclabel.m#L60-L62
-    return labels
+        # outputs are ordered as in
+        # https://github.com/sccn/ICLabel/blob/e8abc99e0c371ff49eff115cf7955fafc7f7969a/iclabel.m#L60-L62
+        return labels
+    elif library == "onnx":
+        # Get network
+        onnx_network_file = files("mne_icalabel.iclabel").joinpath("assets/ICLabelNet.onnx")
+        ort_session = ort.InferenceSession(onnx_network_file)
+
+        # Format input and get labels
+        topo_npy, psds_npy, autocorr_npy = _format_input_for_onnx(
+            *_format_input(images, psds, autocorr)
+        )
+
+        labels = ort_session.run(
+            None,
+            {"topo": topo_npy, "psds": psds_npy, "autocorr": autocorr_npy},
+        )
+
+        # outputs are ordered as in
+        # https://github.com/sccn/ICLabel/blob/e8abc99e0c371ff49eff115cf7955fafc7f7969a/iclabel.m#L60-L62
+        return labels[0]
+    else:
+        raise ValueError(f"Library {library} is not supported")

--- a/mne_icalabel/iclabel/tests/test_network.py
+++ b/mne_icalabel/iclabel/tests/test_network.py
@@ -4,6 +4,7 @@ except ImportError:
     from importlib_resources import files  # type: ignore
 
 import numpy as np
+import onnxruntime as ort
 import pytest
 import torch
 from scipy.io import loadmat
@@ -16,6 +17,7 @@ dataset_path = icalabel.data_path() / "iclabel"
 
 # Network weights
 torch_iclabel_path = str(files("mne_icalabel.iclabel").joinpath("assets/iclabelNet.pt"))
+onnx_network_file = files("mne_icalabel.iclabel").joinpath("assets/ICLabelNet.onnx")
 matconvnet_iclabel_path = dataset_path / "network/netICL.mat"
 
 # Network forward pass input/output
@@ -35,7 +37,7 @@ iclabel_output_raw_path = dataset_path / "iclabel-output-raw.mat"
 iclabel_output_epo_path = dataset_path / "iclabel-output-epo.mat"
 
 
-def test_weights():
+def test_weights_pytorch():
     """Compare the weights of pytorch model and matconvnet model."""
     network_python = torch.load(torch_iclabel_path)
     network_matlab = loadmat(matconvnet_iclabel_path)
@@ -81,9 +83,9 @@ def test_weights():
         assert np.allclose(network_python[python_layer], weights_matlab[idx])
 
 
-def test_network_outputs():
+def test_network_outputs_pytorch():
     """
-    Compare that the ICLabel network in python and matlab outputs the same
+    Compare that the ICLabel network in pytorch and matlab outputs the same
     values for a common set of features (input to the forward pass).
 
     Notes
@@ -126,6 +128,50 @@ def test_network_outputs():
     assert np.allclose(matlab_labels, torch_labels, atol=1e-7)
 
 
+def test_network_outputs_onnx():
+    """
+    Compare that the ICLabel network in onnx and matlab outputs the same
+    values for a common set of features (input to the forward pass).
+
+    Notes
+    -----
+    The forward pass has been run in matconvnet with the same input features.
+    The corresponding MATLAB code can be found in 'data/network_output.txt'.
+    """
+    # load features to use for the forward pass
+    features = loadmat(matconvnet_fw_input_path)["input"][0, :]
+    # features is a (6, ) array with:
+    # - elements in position [0, 2, 4] -> 1-element array with the var name
+    # - elements in position [1, 3, 5] -> data arrays
+    assert "in_image" == features[0][0]
+    images = features[1]
+    assert "in_psdmed" == features[2][0]
+    psd = features[3]
+    assert "in_autocorr" == features[4][0]
+    autocorr = features[5]
+
+    # reshape the features to fit torch format
+    images = np.transpose(images, (3, 2, 0, 1)).astype(np.float32)
+    psd = np.transpose(psd, (3, 2, 0, 1)).astype(np.float32)
+    autocorr = np.transpose(autocorr, (3, 2, 0, 1)).astype(np.float32)
+
+    # run the forward pass on onnxruntime
+    ort_session = ort.InferenceSession(onnx_network_file)
+
+    labels = ort_session.run(
+        None,
+        {"topo": images, "psds": psd, "autocorr": autocorr},
+    )
+
+    onnx_labels = labels[0]
+
+    # load the matconvnet output of the forward pass on those 3 feature arrays
+    matlab_labels = loadmat(matconvnet_fw_output_path)["labels"]  # (30, 7)
+
+    # Compare both outputs
+    assert np.allclose(matlab_labels, onnx_labels, atol=1e-7)
+
+
 @pytest.mark.parametrize(
     "eeglab_feature_file, eeglab_feature_formatted_file",
     [
@@ -133,7 +179,7 @@ def test_network_outputs():
         (features_epo_path, features_formatted_epo_path),
     ],
 )
-def test_format_input(eeglab_feature_file, eeglab_feature_formatted_file):
+def test_format_input_pytorch(eeglab_feature_file, eeglab_feature_formatted_file):
     """Test formatting of input feature before feeding them to the network."""
     features_eeglab = loadmat(eeglab_feature_file)["features"]
     topo, psd, autocorr = _format_input(
@@ -157,14 +203,37 @@ def test_format_input(eeglab_feature_file, eeglab_feature_formatted_file):
         (features_epo_path, iclabel_output_epo_path),
     ],
 )
-def test_run_iclabel(eeglab_feature_file, eeglab_output_file):
+def test_run_iclabel_onnx(eeglab_feature_file, eeglab_output_file):
+    """Test that the network outputs the same values for the features in
+    'features_raw_path' and 'features_epo_path' that contains the features
+    extracted in EEGLAB. This set of feature is compared with the set of
+    features retrieved in python in 'test_features.py:test_get_features'."""
+    features_eeglab = loadmat(eeglab_feature_file)["features"]
+    # run the forward pass on onnx
+    labels = run_iclabel(features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2], library = 'onnx')
+
+    # load the labels from EEGLAB
+    matlab_labels = loadmat(eeglab_output_file)["labels"]  # (30, 7)
+
+    # Compare both outputs
+    assert np.allclose(matlab_labels, labels, atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    "eeglab_feature_file, eeglab_output_file",
+    [
+        (features_raw_path, iclabel_output_raw_path),
+        (features_epo_path, iclabel_output_epo_path),
+    ],
+)
+def test_run_iclabel_pytorch(eeglab_feature_file, eeglab_output_file):
     """Test that the network outputs the same values for the features in
     'features_raw_path' and 'features_epo_path' that contains the features
     extracted in EEGLAB. This set of feature is compared with the set of
     features retrieved in python in 'test_features.py:test_get_features'."""
     features_eeglab = loadmat(eeglab_feature_file)["features"]
     # run the forward pass on pytorch
-    labels = run_iclabel(features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2])
+    labels = run_iclabel(features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2], library = 'pytorch')
 
     # load the labels from EEGLAB
     matlab_labels = loadmat(eeglab_output_file)["labels"]  # (30, 7)

--- a/mne_icalabel/iclabel/tests/test_network.py
+++ b/mne_icalabel/iclabel/tests/test_network.py
@@ -210,7 +210,9 @@ def test_run_iclabel_onnx(eeglab_feature_file, eeglab_output_file):
     features retrieved in python in 'test_features.py:test_get_features'."""
     features_eeglab = loadmat(eeglab_feature_file)["features"]
     # run the forward pass on onnx
-    labels = run_iclabel(features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2], library = 'onnx')
+    labels = run_iclabel(
+        features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2], library="onnx"
+    )
 
     # load the labels from EEGLAB
     matlab_labels = loadmat(eeglab_output_file)["labels"]  # (30, 7)
@@ -233,7 +235,9 @@ def test_run_iclabel_pytorch(eeglab_feature_file, eeglab_output_file):
     features retrieved in python in 'test_features.py:test_get_features'."""
     features_eeglab = loadmat(eeglab_feature_file)["features"]
     # run the forward pass on pytorch
-    labels = run_iclabel(features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2], library = 'pytorch')
+    labels = run_iclabel(
+        features_eeglab[0, 0], features_eeglab[0, 1], features_eeglab[0, 2], library="pytorch"
+    )
 
     # load the labels from EEGLAB
     matlab_labels = loadmat(eeglab_output_file)["labels"]  # (30, 7)

--- a/mne_icalabel/iclabel/tests/test_network.py
+++ b/mne_icalabel/iclabel/tests/test_network.py
@@ -150,7 +150,7 @@ def test_network_outputs_onnx():
     assert "in_autocorr" == features[4][0]
     autocorr = features[5]
 
-    # reshape the features to fit torch format
+    # reshape the features to fit onnx format
     images = np.transpose(images, (3, 2, 0, 1)).astype(np.float32)
     psd = np.transpose(psd, (3, 2, 0, 1)).astype(np.float32)
     autocorr = np.transpose(autocorr, (3, 2, 0, 1)).astype(np.float32)
@@ -179,7 +179,7 @@ def test_network_outputs_onnx():
         (features_epo_path, features_formatted_epo_path),
     ],
 )
-def test_format_input_pytorch(eeglab_feature_file, eeglab_feature_formatted_file):
+def test_format_input(eeglab_feature_file, eeglab_feature_formatted_file):
     """Test formatting of input feature before feeding them to the network."""
     features_eeglab = loadmat(eeglab_feature_file)["features"]
     topo, psd, autocorr = _format_input(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ include = ['mne_icalabel*']
 exclude = ['mne_icalabel*tests']
 
 [tool.setuptools.package-data]
-"mne_icalabel.iclabel" = ["assets/*.pt"]
+"mne_icalabel.iclabel" = ["assets/*"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     'mne >= 1.1',
     'pooch',
     'torch',
+    'onnxruntime',
     'importlib-resources; python_version<"3.9"',
 ]
 
@@ -56,7 +57,7 @@ doc = [
     'memory_profiler',
     'numpydoc',
     'pydata-sphinx-theme',
-    'PyQt5',
+    'PyQt6',
     'sphinx',
     'sphinxcontrib-bibtex',
     'sphinx-copybutton',


### PR DESCRIPTION
PR Description
--------------

Added ONNX support to iclabel. I changed the function `run_iclabel` to include a library parameter. This parameter's default value is set to use PyTorch. I added unit tests to check the network outputs against MATLAB. ONNX is faster to load and more lightweight than PyTorch.

The options for the `library` parameter are `pytorch` and `onnx` so far. It throws a `ValueError` for any other input.

Closes #125.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-icalabel/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
