### PR TITLE
Fix missed Qt dependency in stubs workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ stubs = [
   'mne-icalabel[onnx]',
   'mne-icalabel[torch]',
   'mypy',
+  'PyQt6',
   'ruff>=0.1.8',
 ]
 style = [


### PR DESCRIPTION
It's gonna work at some point.