### PR TITLE
FIX: explicitly set weights_only to avoid FutureWarning

### DIFF
--- a/doc/changes/authors.inc
+++ b/doc/changes/authors.inc
@@ -2,3 +2,4 @@
 .. _Mathieu Scheltienne: https://github.com/mscheltienne
 .. _Jacob Feitelberg: https://github.com/jacobf18
 .. _Anand Saini: https://github.com/anandsaini024
+.. _Scott Huberty: https://github.com/scott-huberty

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -18,4 +18,4 @@ Version 0.7
 ===========
 
 - Raise helpful error message when montage is incomplete (:pr:`181` by `Mathieu Scheltienne`_)
-- Explicitly pass ``weights_only=False`` in all instances of ``torch.load`` used by mne-icalabel, to suppress a warning in PyTorch 2.4 (:pr:`193` by `Scott Huberty`_)
+- Explicitly pass ``weights_only=True`` in all instances of ``torch.load`` used by mne-icalabel, both to suppress a warning in PyTorch 2.4 and to follow best security practices (:pr:`193` by `Scott Huberty`_)

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -18,3 +18,4 @@ Version 0.7
 ===========
 
 - Raise helpful error message when montage is incomplete (:pr:`181` by `Mathieu Scheltienne`_)
+- Explicitly pass ``weights_only=False`` in all instances of ``torch.load`` used by mne-icalabel, to suppress a warning in PyTorch 2.4 (:pr:`193` by `Scott Huberty`_)

--- a/mne_icalabel/iclabel/network/tests/test_network.py
+++ b/mne_icalabel/iclabel/network/tests/test_network.py
@@ -36,8 +36,8 @@ iclabel_output_epo_path = dataset_path / "iclabel-output-epo.mat"
 
 def test_weights_pytorch():
     """Compare the weights of pytorch model and matconvnet model."""
-    network_python = torch.load(torch_iclabel_path)
-    network_matlab = loadmat(matconvnet_iclabel_path)
+    network_python = torch.load(torch_iclabel_path, weights_only=False)
+    network_matlab = loadmat(matconvnet_iclabel_path, weights_only=False)
 
     # load weights from matlab network
     weights_matlab = network_matlab["params"]["value"][0, :]

--- a/mne_icalabel/iclabel/network/tests/test_network.py
+++ b/mne_icalabel/iclabel/network/tests/test_network.py
@@ -119,7 +119,7 @@ def test_network_outputs_pytorch():
 
     # run the forward pass on pytorch
     iclabel_net = ICLabelNet()
-    iclabel_net.load_state_dict(torch.load(torch_iclabel_path))
+    iclabel_net.load_state_dict(torch.load(torch_iclabel_path, weights_only=False))
     torch_labels = iclabel_net(images, psd, autocorr)
     torch_labels = torch_labels.detach().numpy()  # (30, 7)
 

--- a/mne_icalabel/iclabel/network/tests/test_network.py
+++ b/mne_icalabel/iclabel/network/tests/test_network.py
@@ -37,7 +37,7 @@ iclabel_output_epo_path = dataset_path / "iclabel-output-epo.mat"
 def test_weights_pytorch():
     """Compare the weights of pytorch model and matconvnet model."""
     network_python = torch.load(torch_iclabel_path, weights_only=False)
-    network_matlab = loadmat(matconvnet_iclabel_path, weights_only=False)
+    network_matlab = loadmat(matconvnet_iclabel_path)
 
     # load weights from matlab network
     weights_matlab = network_matlab["params"]["value"][0, :]

--- a/mne_icalabel/iclabel/network/tests/test_network.py
+++ b/mne_icalabel/iclabel/network/tests/test_network.py
@@ -36,7 +36,7 @@ iclabel_output_epo_path = dataset_path / "iclabel-output-epo.mat"
 
 def test_weights_pytorch():
     """Compare the weights of pytorch model and matconvnet model."""
-    network_python = torch.load(torch_iclabel_path, weights_only=False)
+    network_python = torch.load(torch_iclabel_path, weights_only=True)
     network_matlab = loadmat(matconvnet_iclabel_path)
 
     # load weights from matlab network
@@ -119,7 +119,7 @@ def test_network_outputs_pytorch():
 
     # run the forward pass on pytorch
     iclabel_net = ICLabelNet()
-    iclabel_net.load_state_dict(torch.load(torch_iclabel_path, weights_only=False))
+    iclabel_net.load_state_dict(torch.load(torch_iclabel_path, weights_only=True))
     torch_labels = iclabel_net(images, psd, autocorr)
     torch_labels = torch_labels.detach().numpy()  # (30, 7)
 

--- a/mne_icalabel/iclabel/network/torch.py
+++ b/mne_icalabel/iclabel/network/torch.py
@@ -198,7 +198,7 @@ def _run_iclabel(images: ArrayLike, psds: ArrayLike, autocorr: ArrayLike) -> NDA
     # load weights
     network_file = files("mne_icalabel.iclabel.network") / "assets" / "ICLabelNet.pt"
     iclabel_net = ICLabelNet()
-    iclabel_net.load_state_dict(torch.load(network_file, weights_only=False))
+    iclabel_net.load_state_dict(torch.load(network_file, weights_only=True))
     # format inputs and run forward pass
     labels = iclabel_net(
         *_format_input_for_torch(*_format_input(images, psds, autocorr))

--- a/mne_icalabel/iclabel/network/torch.py
+++ b/mne_icalabel/iclabel/network/torch.py
@@ -198,7 +198,7 @@ def _run_iclabel(images: ArrayLike, psds: ArrayLike, autocorr: ArrayLike) -> NDA
     # load weights
     network_file = files("mne_icalabel.iclabel.network") / "assets" / "ICLabelNet.pt"
     iclabel_net = ICLabelNet()
-    iclabel_net.load_state_dict(torch.load(network_file))
+    iclabel_net.load_state_dict(torch.load(network_file, weights_only=False))
     # format inputs and run forward pass
     labels = iclabel_net(
         *_format_input_for_torch(*_format_input(images, psds, autocorr))


### PR DESCRIPTION
Closes #192 

If I'm understanding the Torch 2.4 changelog correctly, you just need to explicitly pass a value to `weights_only` to suppress the warning. Since the default is already `False`, I am just explicitly setting it here, so this should be backward compatible

I'll double check that the CI installs 2.4 so we can make sure this fix works. 

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] All CIs are happy
- [x] Updated a changelog entry and contributor name in [whats_new.rst](https://github.com/mne-tools/mne-icalabel/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
