### PR TITLE
add MEGnet to make MNE-ICALabel work on MEG data

### DIFF
--- a/mne_icalabel/megnet/_utils.py
+++ b/mne_icalabel/megnet/_utils.py
@@ -1,0 +1,45 @@
+#%%
+import numpy as np
+
+# Conversion functions
+def cart2sph(x, y, z):
+    xy = np.sqrt(x * x + y * y)
+    r = np.sqrt(x * x + y * y + z * z)
+    theta = np.arctan2(y, x)
+    phi = np.arctan2(z, xy)
+    return r, theta, phi
+
+def pol2cart(rho, phi):
+    x = rho * np.cos(phi)
+    y = rho * np.sin(phi)
+    return x, y
+
+
+def make_head_outlines(sphere, pos, outlines, clip_origin):
+    assert isinstance(sphere, np.ndarray)
+    x, y, _, radius = sphere
+    del sphere
+
+    ll = np.linspace(0, 2 * np.pi, 101)
+    head_x = np.cos(ll) * radius * 1.01 + x
+    head_y = np.sin(ll) * radius * 1.01 + y
+    dx = np.exp(np.arccos(np.deg2rad(12)) * 1j)
+    dx, dy = dx.real, dx.imag
+    
+    outlines_dict = dict(head=(head_x, head_y))
+    
+    mask_scale = 1.
+    mask_scale = max(
+        mask_scale, np.linalg.norm(pos, axis=1).max() * 1.01 / radius
+    )
+    
+    outlines_dict['mask_pos'] = (mask_scale * head_x, mask_scale * head_y)
+    clip_radius = radius * mask_scale
+    outlines_dict['clip_radius'] = (clip_radius,) * 2
+    outlines_dict['clip_origin'] = clip_origin
+    
+    outlines = outlines_dict
+    
+    return outlines
+
+

--- a/mne_icalabel/megnet/_utils.py
+++ b/mne_icalabel/megnet/_utils.py
@@ -1,5 +1,6 @@
-#%%
+# %%
 import numpy as np
+
 
 # Conversion functions
 def cart2sph(x, y, z):
@@ -8,6 +9,7 @@ def cart2sph(x, y, z):
     theta = np.arctan2(y, x)
     phi = np.arctan2(z, xy)
     return r, theta, phi
+
 
 def pol2cart(rho, phi):
     x = rho * np.cos(phi)
@@ -24,22 +26,19 @@ def make_head_outlines(sphere, pos, outlines, clip_origin):
     head_x = np.cos(ll) * radius * 1.01 + x
     head_y = np.sin(ll) * radius * 1.01 + y
     dx = np.exp(np.arccos(np.deg2rad(12)) * 1j)
-    dx, dy = dx.real, dx.imag
-    
+    dx, _ = dx.real, dx.imag
+
     outlines_dict = dict(head=(head_x, head_y))
-    
-    mask_scale = 1.
-    mask_scale = max(
-        mask_scale, np.linalg.norm(pos, axis=1).max() * 1.01 / radius
-    )
-    
-    outlines_dict['mask_pos'] = (mask_scale * head_x, mask_scale * head_y)
+
+    mask_scale = 1.0
+    max_norm = np.linalg.norm(pos, axis=1).max()
+    mask_scale = max(mask_scale, max_norm * 1.01 / radius)
+
+    outlines_dict["mask_pos"] = (mask_scale * head_x, mask_scale * head_y)
     clip_radius = radius * mask_scale
-    outlines_dict['clip_radius'] = (clip_radius,) * 2
-    outlines_dict['clip_origin'] = clip_origin
-    
+    outlines_dict["clip_radius"] = (clip_radius,) * 2
+    outlines_dict["clip_origin"] = clip_origin
+
     outlines = outlines_dict
-    
+
     return outlines
-
-

--- a/mne_icalabel/megnet/features.py
+++ b/mne_icalabel/megnet/features.py
@@ -1,29 +1,33 @@
-import numpy as np
-from scipy.spatial import ConvexHull
-from scipy import interpolate
-import matplotlib.pyplot as plt
 import io
-from PIL import Image
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-import mne
-from mne.io import BaseRaw
-from mne.preprocessing import ICA
-from _utils import cart2sph, pol2cart
+
+import matplotlib.pyplot as plt
+import mne # type: ignore
+import numpy as np
+from mne.io import BaseRaw # type: ignore
+from mne.preprocessing import ICA # type: ignore
+from mne.utils import warn # type: ignore
 from numpy.typing import NDArray
-from mne.utils import warn
+from PIL import Image
+from scipy import interpolate # type: ignore
+from scipy.spatial import ConvexHull # type: ignore
+
+from _utils import cart2sph, pol2cart
 
 
-def get_megnet_features(raw:BaseRaw, ica:ICA):
+def get_megnet_features(raw: BaseRaw, ica: ICA):
     """
-    Extract time series and topomaps for each ICA component. the main work is focused on making BrainStorm-like topomaps which trained the MEGnet.
-    
+    Extract time series and topomaps for each ICA component.
+    the main work is focused on making BrainStorm-like topomaps
+    which trained the MEGnet.
+
     Parameters
     ----------
     raw : BaseRaw
-        The raw MEG data. The raw instance should have 250 Hz sampling frequency and more than 60 seconds.
+        The raw MEG data. The raw instance should have 250 Hz
+        sampling frequency and more than 60 seconds.
     ica : ICA
         The ICA object containing the independent components.
-    
+
     Returns
     -------
     time_series : np.ndarray
@@ -37,29 +41,32 @@ def get_megnet_features(raw:BaseRaw, ica:ICA):
             "Raw instance. The MEGnet model was fitted on"
             "MEG data and is not suited for other types of channels."
         )
-    
+
     if raw.times[-1] < 60:
         raise RuntimeError(
             f"The provided raw instance has {raw.times[-1]} seconds. "
-            "MEGnet was designed to classify features extracted from an MEG dataset "
-            "at least 60 seconds long. "
+            "MEGnet was designed to classify features extracted from "
+            "an MEG datasetat least 60 seconds long. "
         )
-    
-    if not np.isclose(raw.info['sfreq'], 250, atol=1e-1):
+
+    if not np.isclose(raw.info["sfreq"], 250, atol=1e-1):
         warn(
-            f"The provided raw instance is not sampled at 250 Hz (sfreq={raw.info['sfreq']} Hz). "
-            "MEGnet was designed to classify features extracted from an MEG dataset "
-            "sampled at 250 Hz (see the 'resample()' method for raw). "
+            "The provided raw instance is not sampled at 250 Hz"
+            f"(sfreq={raw.info['sfreq']} Hz). "
+            "MEGnet was designed to classify features extracted from"
+            "an MEG dataset sampled at 250 Hz"
+            "(see the 'resample()' method for raw)."
             "The classification performance might be negatively impacted."
         )
-        
+
     pos_new, outlines = _get_topomaps_data(ica)
     topomaps = _get_topomaps(ica, pos_new, outlines)
     time_series = ica.get_sources(raw)._data
 
     return time_series, topomaps
 
-def _make_head_outlines(sphere:NDArray, pos:NDArray, clip_origin:tuple):
+
+def _make_head_outlines(sphere: NDArray, pos: NDArray, clip_origin: tuple):
     """
     Generate head outlines and mask positions for the topomap plot.
     """
@@ -68,29 +75,35 @@ def _make_head_outlines(sphere:NDArray, pos:NDArray, clip_origin:tuple):
     head_x = np.cos(ll) * radius * 1.01 + x
     head_y = np.sin(ll) * radius * 1.01 + y
 
-    mask_scale = max(1., np.linalg.norm(pos, axis=1).max() * 1.01 / radius)
+    mask_scale = max(1.0, np.linalg.norm(pos, axis=1).max() * 1.01 / radius)
     clip_radius = radius * mask_scale
 
     outlines_dict = {
-        'head': (head_x, head_y),
-        'mask_pos': (mask_scale * head_x, mask_scale * head_y),
-        'clip_radius': (clip_radius,) * 2,
-        'clip_origin': clip_origin
+        "head": (head_x, head_y),
+        "mask_pos": (mask_scale * head_x, mask_scale * head_y),
+        "clip_radius": (clip_radius,) * 2,
+        "clip_origin": clip_origin,
     }
     return outlines_dict
 
-def _get_topomaps_data(ica:ICA):
+
+def _get_topomaps_data(ica: ICA):
     """
     Prepare 2D sensor positions and outlines for topomap plotting.
     """
-    mags = mne.pick_types(ica.info, meg='mag')
-    channel_info = ica.info['chs']
-    channel_locations_3d = np.array([channel_info[i]['loc'][0:3] for i in mags])
+    mags = mne.pick_types(ica.info, meg="mag")
+    channel_info = ica.info["chs"]
+    loc_3d = [channel_info[i]["loc"][0:3] for i in mags]
+    channel_locations_3d = np.array(loc_3d)
 
     # Convert to spherical and then to 2D
-    sph_coords = np.transpose(cart2sph(channel_locations_3d[:, 0], 
-                                       channel_locations_3d[:, 1], 
-                                       channel_locations_3d[:, 2]))
+    sph_coords = np.transpose(
+        cart2sph(
+            channel_locations_3d[:, 0],
+            channel_locations_3d[:, 1],
+            channel_locations_3d[:, 2],
+        )
+    )
     TH, PHI = sph_coords[:, 1], sph_coords[:, 2]
     newR = 1 - PHI / np.pi * 2
     channel_locations_2d = np.transpose(pol2cart(newR, TH))
@@ -100,7 +113,13 @@ def _get_topomaps_data(ica:ICA):
     border_indices = hull.vertices
     Dborder = 1 / newR[border_indices]
 
-    funcTh = np.hstack([TH[border_indices] - 2 * np.pi, TH[border_indices], TH[border_indices] + 2 * np.pi])
+    funcTh = np.hstack(
+        [
+            TH[border_indices] - 2 * np.pi,
+            TH[border_indices],
+            TH[border_indices] + 2 * np.pi,
+        ]
+    )
     funcD = np.hstack((Dborder, Dborder, Dborder))
     interp_func = interpolate.interp1d(funcTh, funcD)
     D = interp_func(TH)
@@ -112,51 +131,56 @@ def _get_topomaps_data(ica:ICA):
     outlines = _make_head_outlines(np.array([0, 0, 0, 1]), pos_new, (0, 0))
     return pos_new, outlines
 
-def _get_topomaps(ica:ICA, pos_new:NDArray, outlines:dict):
+
+def _get_topomaps(ica: ICA, pos_new: NDArray, outlines: dict):
     """
     Generate topomap images for each ICA component.
     """
     topomaps = []
-    data_picks, _, _, _, _, _, _ = mne.viz.topomap._prepare_topomap_plot(ica, ch_type='mag')
+    data_picks, _, _, _, _, _, _ = mne.viz.topomap._prepare_topomap_plot(
+        ica, ch_type="mag"
+    )
     components = ica.get_components()
 
     for comp in range(ica.n_components_):
         data = components[data_picks, comp]
-        # fig, ax = plt.subplots(figsize=(1.3, 1.3), dpi=100, facecolor='black')
-        fig = plt.figure(figsize=(1.3, 1.3), dpi=100, facecolor='black')
+        fig = plt.figure(figsize=(1.3, 1.3), dpi=100, facecolor="black")
         ax = fig.add_subplot(111)
-        mnefig, _ = mne.viz.plot_topomap(data, 
-                                       pos_new, 
-                                       sensors=False, 
-                                       outlines=outlines, 
-                                       extrapolate='head', 
-                                       sphere=[0, 0, 0, 1], 
-                                       contours=10, 
-                                       res=120, 
-                                       axes=ax,
-                                       show=False, 
-                                       cmap='bwr')
+        mnefig, _ = mne.viz.plot_topomap(
+            data,
+            pos_new,
+            sensors=False,
+            outlines=outlines,
+            extrapolate="head",
+            sphere=[0, 0, 0, 1],
+            contours=10,
+            res=120,
+            axes=ax,
+            show=False,
+            cmap="bwr",
+        )
         img_buf = io.BytesIO()
-        mnefig.figure.savefig(img_buf, format='png', dpi=120, bbox_inches='tight', pad_inches=0)
-        img_buf.seek(0) 
+        mnefig.figure.savefig(
+            img_buf, format="png", dpi=120, bbox_inches="tight", pad_inches=0
+        )
+        img_buf.seek(0)
         rgba_image = Image.open(img_buf)
-        rgb_image = rgba_image.convert('RGB')
-        img_buf.close() 
+        rgb_image = rgba_image.convert("RGB")
+        img_buf.close()
         plt.close(fig)
-        
+
         topomaps.append(np.array(rgb_image))
-        
+
     return np.array(topomaps)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_dir = mne.datasets.sample.data_path()
-    sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
+    sample_fname = sample_dir / "MEG" / "sample" / "sample_audvis_raw.fif"
 
-    raw = mne.io.read_raw_fif(sample_fname).pick_types('mag')
-    
-    ica = mne.preprocessing.ICA(n_components=20, max_iter='auto', method='infomax')
+    raw = mne.io.read_raw_fif(sample_fname).pick_types("mag")
+
+    ica = mne.preprocessing.ICA(n_components=20, method="infomax")
     ica.fit(raw)
 
     time_series, topomaps = get_megnet_features(raw, ica)
@@ -166,6 +190,6 @@ if __name__ == '__main__':
         row, col = divmod(i, 5)
         ax = axes[row, col]
         ax.imshow(comp)
-        ax.axis('off')
+        ax.axis("off")
     fig.tight_layout()
     fig.show()

--- a/mne_icalabel/megnet/features.py
+++ b/mne_icalabel/megnet/features.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     sample_fname = sample_dir / "MEG" / "sample" / "sample_audvis_raw.fif"
 
     raw = mne.io.read_raw_fif(sample_fname).pick_types("mag")
-
+    raw.resample(250)
     ica = mne.preprocessing.ICA(n_components=20, method="infomax")
     ica.fit(raw)
 
@@ -192,4 +192,4 @@ if __name__ == "__main__":
         ax.imshow(comp)
         ax.axis("off")
     fig.tight_layout()
-    fig.show()
+    plt.show()

--- a/mne_icalabel/megnet/features.py
+++ b/mne_icalabel/megnet/features.py
@@ -1,0 +1,171 @@
+import numpy as np
+from scipy.spatial import ConvexHull
+from scipy import interpolate
+import matplotlib.pyplot as plt
+import io
+from PIL import Image
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+import mne
+from mne.io import BaseRaw
+from mne.preprocessing import ICA
+from _utils import cart2sph, pol2cart
+from numpy.typing import NDArray
+from mne.utils import warn
+
+
+def get_megnet_features(raw:BaseRaw, ica:ICA):
+    """
+    Extract time series and topomaps for each ICA component. the main work is focused on making BrainStorm-like topomaps which trained the MEGnet.
+    
+    Parameters
+    ----------
+    raw : BaseRaw
+        The raw MEG data. The raw instance should have 250 Hz sampling frequency and more than 60 seconds.
+    ica : ICA
+        The ICA object containing the independent components.
+    
+    Returns
+    -------
+    time_series : np.ndarray
+        The time series for each ICA component.
+    topomaps : np.ndarray
+        The topomaps for each ICA component
+    """
+    if "meg" not in raw:
+        raise RuntimeError(
+            "Could not find MEG channels in the provided "
+            "Raw instance. The MEGnet model was fitted on"
+            "MEG data and is not suited for other types of channels."
+        )
+    
+    if raw.times[-1] < 60:
+        raise RuntimeError(
+            f"The provided raw instance has {raw.times[-1]} seconds. "
+            "MEGnet was designed to classify features extracted from an MEG dataset "
+            "at least 60 seconds long. "
+        )
+    
+    if not np.isclose(raw.info['sfreq'], 250, atol=1e-1):
+        warn(
+            f"The provided raw instance is not sampled at 250 Hz (sfreq={raw.info['sfreq']} Hz). "
+            "MEGnet was designed to classify features extracted from an MEG dataset "
+            "sampled at 250 Hz (see the 'resample()' method for raw). "
+            "The classification performance might be negatively impacted."
+        )
+        
+    pos_new, outlines = _get_topomaps_data(ica)
+    topomaps = _get_topomaps(ica, pos_new, outlines)
+    time_series = ica.get_sources(raw)._data
+
+    return time_series, topomaps
+
+def _make_head_outlines(sphere:NDArray, pos:NDArray, clip_origin:tuple):
+    """
+    Generate head outlines and mask positions for the topomap plot.
+    """
+    x, y, _, radius = sphere
+    ll = np.linspace(0, 2 * np.pi, 101)
+    head_x = np.cos(ll) * radius * 1.01 + x
+    head_y = np.sin(ll) * radius * 1.01 + y
+
+    mask_scale = max(1., np.linalg.norm(pos, axis=1).max() * 1.01 / radius)
+    clip_radius = radius * mask_scale
+
+    outlines_dict = {
+        'head': (head_x, head_y),
+        'mask_pos': (mask_scale * head_x, mask_scale * head_y),
+        'clip_radius': (clip_radius,) * 2,
+        'clip_origin': clip_origin
+    }
+    return outlines_dict
+
+def _get_topomaps_data(ica:ICA):
+    """
+    Prepare 2D sensor positions and outlines for topomap plotting.
+    """
+    mags = mne.pick_types(ica.info, meg='mag')
+    channel_info = ica.info['chs']
+    channel_locations_3d = np.array([channel_info[i]['loc'][0:3] for i in mags])
+
+    # Convert to spherical and then to 2D
+    sph_coords = np.transpose(cart2sph(channel_locations_3d[:, 0], 
+                                       channel_locations_3d[:, 1], 
+                                       channel_locations_3d[:, 2]))
+    TH, PHI = sph_coords[:, 1], sph_coords[:, 2]
+    newR = 1 - PHI / np.pi * 2
+    channel_locations_2d = np.transpose(pol2cart(newR, TH))
+
+    # Adjust coordinates with convex hull interpolation
+    hull = ConvexHull(channel_locations_2d)
+    border_indices = hull.vertices
+    Dborder = 1 / newR[border_indices]
+
+    funcTh = np.hstack([TH[border_indices] - 2 * np.pi, TH[border_indices], TH[border_indices] + 2 * np.pi])
+    funcD = np.hstack((Dborder, Dborder, Dborder))
+    interp_func = interpolate.interp1d(funcTh, funcD)
+    D = interp_func(TH)
+
+    adjusted_R = np.array([min(newR[i] * D[i], 1) for i in range(len(mags))])
+    Xnew, Ynew = pol2cart(adjusted_R, TH)
+    pos_new = np.vstack((Xnew, Ynew)).T
+
+    outlines = _make_head_outlines(np.array([0, 0, 0, 1]), pos_new, (0, 0))
+    return pos_new, outlines
+
+def _get_topomaps(ica:ICA, pos_new:NDArray, outlines:dict):
+    """
+    Generate topomap images for each ICA component.
+    """
+    topomaps = []
+    data_picks, _, _, _, _, _, _ = mne.viz.topomap._prepare_topomap_plot(ica, ch_type='mag')
+    components = ica.get_components()
+
+    for comp in range(ica.n_components_):
+        data = components[data_picks, comp]
+        # fig, ax = plt.subplots(figsize=(1.3, 1.3), dpi=100, facecolor='black')
+        fig = plt.figure(figsize=(1.3, 1.3), dpi=100, facecolor='black')
+        ax = fig.add_subplot(111)
+        mnefig, _ = mne.viz.plot_topomap(data, 
+                                       pos_new, 
+                                       sensors=False, 
+                                       outlines=outlines, 
+                                       extrapolate='head', 
+                                       sphere=[0, 0, 0, 1], 
+                                       contours=10, 
+                                       res=120, 
+                                       axes=ax,
+                                       show=False, 
+                                       cmap='bwr')
+        img_buf = io.BytesIO()
+        mnefig.figure.savefig(img_buf, format='png', dpi=120, bbox_inches='tight', pad_inches=0)
+        img_buf.seek(0) 
+        rgba_image = Image.open(img_buf)
+        rgb_image = rgba_image.convert('RGB')
+        img_buf.close() 
+        plt.close(fig)
+        
+        topomaps.append(np.array(rgb_image))
+        
+    return np.array(topomaps)
+
+
+
+if __name__ == '__main__':
+    sample_dir = mne.datasets.sample.data_path()
+    sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
+
+    raw = mne.io.read_raw_fif(sample_fname).pick_types('mag')
+    
+    ica = mne.preprocessing.ICA(n_components=20, max_iter='auto', method='infomax')
+    ica.fit(raw)
+
+    time_series, topomaps = get_megnet_features(raw, ica)
+
+    fig, axes = plt.subplots(4, 5)
+    for i, comp in enumerate(topomaps):
+        row, col = divmod(i, 5)
+        ax = axes[row, col]
+        ax.imshow(comp)
+        ax.axis('off')
+    fig.tight_layout()
+    fig.show()

--- a/mne_icalabel/megnet/label_componets.py
+++ b/mne_icalabel/megnet/label_componets.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 
     sample_dir = mne.datasets.sample.data_path()
     sample_fname = sample_dir / "MEG" / "sample" / "sample_audvis_raw.fif"
-    raw = mne.io.read_raw_fif(sample_fname).pick_types("mag")
+    raw = mne.io.read_raw_fif(sample_fname).pick("mag")
     raw.resample(250)
     raw.filter(1, 100)
     ica = mne.preprocessing.ICA(
@@ -143,3 +143,7 @@ if __name__ == "__main__":
     ica.fit(raw)
 
     res = megnet_label_components(raw, ica)
+    print(res)
+    ica.exclude = [i for i, label in enumerate(res["labels"]) if label != "brain/other"]
+    ica.plot_components()
+    

--- a/mne_icalabel/megnet/label_componets.py
+++ b/mne_icalabel/megnet/label_componets.py
@@ -1,21 +1,20 @@
-import numpy as np
-from numpy.typing import NDArray
+import os.path as op
 
+import numpy as np
 import onnxruntime as ort
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
-
-import os.path as op
+from numpy.typing import NDArray
 
 
 def megnet_label_components(
-    raw:BaseRaw, 
-    ica:ICA, 
-    model_path:str = op.join('assets', 'network', 'megnet.onnx'), 
-    )->dict:
-    """ 
-    Predict labels for Independent Component Analysis (ICA) components using MEGnet.
-    
+    raw: BaseRaw,
+    ica: ICA,
+    model_path: str = op.join("assets", "network", "megnet.onnx"),
+) -> dict:
+    """
+    Label the provided ICA components with the MEGnet neural network.
+
     Parameters
     ----------
     raw : BaseRaw
@@ -24,7 +23,7 @@ def megnet_label_components(
         The ICA data.
     model_path : str
         Path to the ONNX model file.
-    
+
     Returns
     -------
     dict
@@ -34,72 +33,89 @@ def megnet_label_components(
             - 'labels' : list of str
                 The predicted labels for each component.
     """
-    time_series,topomaps = get_megnet_features(raw, ica)
-    
-    assert time_series.shape[0] == topomaps.shape[0], "The number of time series should match the number of spatial topomaps."
-    assert topomaps.shape[1:] == (120, 120, 3), "The topomaps should have dimensions [N, 120, 120, 3]."
-    assert time_series.shape[1] >= 15000, "The time series must be at least 15000 samples long."
+    time_series, topomaps = get_megnet_features(raw, ica)
+
+    assert (
+        time_series.shape[0] == topomaps.shape[0]
+    ), "The number of time series should match the number of spatial topomaps."
+    assert topomaps.shape[1:] == (
+        120,
+        120,
+        3,
+    ), "The topomaps should have dimensions [N, 120, 120, 3]."
+    assert (
+        time_series.shape[1] >= 15000
+    ), "The time series must be at least 15000 samples long."
 
     session = ort.InferenceSession(model_path)
-    predictions_vote = _chunk_predicting(session, 
-                                         time_series, 
-                                         topomaps
-                                        )
-    
-    all_labels = ['brain/other', 'eye blink', 'eye movement', 'heart']
+    predictions_vote = _chunk_predicting(session, time_series, topomaps)
+
+    all_labels = ["brain/other", "eye blink", "eye movement", "heart"]
     # megnet_labels = ['NA', 'EB', 'SA', 'CA']
     result = predictions_vote[:, 0, :]
-    labels= [all_labels[i] for i in result.argmax(axis=1)]
+    labels = [all_labels[i] for i in result.argmax(axis=1)]
     proba = [result[i, result[i].argmax()] for i in range(result.shape[0])]
-    
-    
-    return {'y_pred_proba':proba, 'labels':labels}
-    
+
+    return {"y_pred_proba": proba, "labels": labels}
+
+
 def _chunk_predicting(
-    session:ort.InferenceSession, 
-    time_series:NDArray, 
-    spatial_maps:NDArray, 
-    chunk_len=15000, 
-    overlap_len=3750
-    )->NDArray:
-    " Predict the labels for each component using MEGnet's chunk volte algorithm."
+    session: ort.InferenceSession,
+    time_series: NDArray,
+    spatial_maps: NDArray,
+    chunk_len=15000,
+    overlap_len=3750,
+) -> NDArray:
+    """Predict the labels for each component using
+    MEGnet's chunk volte algorithm."""
     predction_vote = []
 
     for comp_series, comp_map in zip(time_series, spatial_maps):
         time_len = comp_series.shape[0]
         start_times = _get_chunk_start(time_len, chunk_len, overlap_len)
-        
+
         if start_times[-1] + chunk_len <= time_len:
             start_times.append(time_len - chunk_len)
-        
+
         chunk_votes = {start: 0 for start in start_times}
         for t in range(time_len):
-            in_chunks = [start <= t < start + chunk_len for start in start_times]
-            num_chunks = np.sum(in_chunks) # how many chunks the time point is in
+            in_chunks = (
+                [start <= t < start + chunk_len for start in start_times]
+            )
+            # how many chunks the time point is in
+            num_chunks = np.sum(in_chunks)
             for start_time, is_in_chunk in zip(start_times, in_chunks):
                 if is_in_chunk:
                     chunk_votes[start_time] += 1.0 / num_chunks
-    
+
         weighted_predictions = {}
         for start_time in chunk_votes.keys():
             onnx_inputs = {
-                session.get_inputs()[0].name: np.expand_dims(comp_map, 0).astype(np.float32),
-                session.get_inputs()[1].name: np.expand_dims(np.expand_dims(comp_series[start_time:start_time + chunk_len], 0), -1).astype(np.float32)
+                session.get_inputs()[0].name:
+                    np.expand_dims(comp_map, 0).astype(np.float32),
+                session.get_inputs()[1].name:
+                    np.expand_dims(
+                    np.expand_dims(
+                        comp_series[start_time: start_time + chunk_len], 0
+                        ), -1).astype(np.float32),
             }
-            prediction = session.run(None, onnx_inputs)[0] 
-            weighted_predictions[start_time] = prediction * chunk_votes[start_time]
+            prediction = session.run(None, onnx_inputs)[0]
+            weighted_predictions[start_time] = (
+                prediction * chunk_votes[start_time]
+            )
 
-        comp_prediction = np.stack(list(weighted_predictions.values())).mean(axis=0)
+        comp_prediction = np.stack(
+            list(weighted_predictions.values())
+            ).mean(axis=0)
         comp_prediction /= comp_prediction.sum()
         predction_vote.append(comp_prediction)
-    
+
     return np.stack(predction_vote)
-    
+
+
 def _get_chunk_start(
-    input_len:int, 
-    chunk_len:int=15000, 
-    overlap_len:int=3750
-    )->list:
+    input_len: int, chunk_len: int = 15000, overlap_len: int = 3750
+) -> list:
     """
     Calculate start times for time series chunks with overlap.
     """
@@ -111,18 +127,19 @@ def _get_chunk_start(
     return start_times
 
 
-
-if __name__ == '__main__':
-    from features import get_megnet_features
+if __name__ == "__main__":
     import mne
 
+    from features import get_megnet_features
+
     sample_dir = mne.datasets.sample.data_path()
-    sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
-    raw = mne.io.read_raw_fif(sample_fname).pick_types('mag')
+    sample_fname = sample_dir / "MEG" / "sample" / "sample_audvis_raw.fif"
+    raw = mne.io.read_raw_fif(sample_fname).pick_types("mag")
     raw.resample(250)
     raw.filter(1, 100)
-    ica = mne.preprocessing.ICA(n_components=20, max_iter='auto', method='infomax')
+    ica = mne.preprocessing.ICA(
+        n_components=20, max_iter="auto", method="infomax"
+        )
     ica.fit(raw)
-    
-    res = megnet_label_components(raw, ica)
 
+    res = megnet_label_components(raw, ica)

--- a/mne_icalabel/megnet/label_componets.py
+++ b/mne_icalabel/megnet/label_componets.py
@@ -1,0 +1,128 @@
+import numpy as np
+from numpy.typing import NDArray
+
+import onnxruntime as ort
+from mne.io import BaseRaw
+from mne.preprocessing import ICA
+
+import os.path as op
+
+
+def megnet_label_components(
+    raw:BaseRaw, 
+    ica:ICA, 
+    model_path:str = op.join('assets', 'network', 'megnet.onnx'), 
+    )->dict:
+    """ 
+    Predict labels for Independent Component Analysis (ICA) components using MEGnet.
+    
+    Parameters
+    ----------
+    raw : BaseRaw
+        The raw MEG data.
+    ica : mne.preprocessing.ICA
+        The ICA data.
+    model_path : str
+        Path to the ONNX model file.
+    
+    Returns
+    -------
+    dict
+        Dictionary with the following keys:
+            - 'y_pred_proba' : list of float
+                The predicted probabilities for each component.
+            - 'labels' : list of str
+                The predicted labels for each component.
+    """
+    time_series,topomaps = get_megnet_features(raw, ica)
+    
+    assert time_series.shape[0] == topomaps.shape[0], "The number of time series should match the number of spatial topomaps."
+    assert topomaps.shape[1:] == (120, 120, 3), "The topomaps should have dimensions [N, 120, 120, 3]."
+    assert time_series.shape[1] >= 15000, "The time series must be at least 15000 samples long."
+
+    session = ort.InferenceSession(model_path)
+    predictions_vote = _chunk_predicting(session, 
+                                         time_series, 
+                                         topomaps
+                                        )
+    
+    all_labels = ['brain/other', 'eye blink', 'eye movement', 'heart']
+    # megnet_labels = ['NA', 'EB', 'SA', 'CA']
+    result = predictions_vote[:, 0, :]
+    labels= [all_labels[i] for i in result.argmax(axis=1)]
+    proba = [result[i, result[i].argmax()] for i in range(result.shape[0])]
+    
+    
+    return {'y_pred_proba':proba, 'labels':labels}
+    
+def _chunk_predicting(
+    session:ort.InferenceSession, 
+    time_series:NDArray, 
+    spatial_maps:NDArray, 
+    chunk_len=15000, 
+    overlap_len=3750
+    )->NDArray:
+    " Predict the labels for each component using MEGnet's chunk volte algorithm."
+    predction_vote = []
+
+    for comp_series, comp_map in zip(time_series, spatial_maps):
+        time_len = comp_series.shape[0]
+        start_times = _get_chunk_start(time_len, chunk_len, overlap_len)
+        
+        if start_times[-1] + chunk_len <= time_len:
+            start_times.append(time_len - chunk_len)
+        
+        chunk_votes = {start: 0 for start in start_times}
+        for t in range(time_len):
+            in_chunks = [start <= t < start + chunk_len for start in start_times]
+            num_chunks = np.sum(in_chunks) # how many chunks the time point is in
+            for start_time, is_in_chunk in zip(start_times, in_chunks):
+                if is_in_chunk:
+                    chunk_votes[start_time] += 1.0 / num_chunks
+    
+        weighted_predictions = {}
+        for start_time in chunk_votes.keys():
+            onnx_inputs = {
+                session.get_inputs()[0].name: np.expand_dims(comp_map, 0).astype(np.float32),
+                session.get_inputs()[1].name: np.expand_dims(np.expand_dims(comp_series[start_time:start_time + chunk_len], 0), -1).astype(np.float32)
+            }
+            prediction = session.run(None, onnx_inputs)[0] 
+            weighted_predictions[start_time] = prediction * chunk_votes[start_time]
+
+        comp_prediction = np.stack(list(weighted_predictions.values())).mean(axis=0)
+        comp_prediction /= comp_prediction.sum()
+        predction_vote.append(comp_prediction)
+    
+    return np.stack(predction_vote)
+    
+def _get_chunk_start(
+    input_len:int, 
+    chunk_len:int=15000, 
+    overlap_len:int=3750
+    )->list:
+    """
+    Calculate start times for time series chunks with overlap.
+    """
+    start_times = []
+    start_time = 0
+    while start_time + chunk_len <= input_len:
+        start_times.append(start_time)
+        start_time += chunk_len - overlap_len
+    return start_times
+
+
+
+if __name__ == '__main__':
+    from features import get_megnet_features
+    import mne
+
+    sample_dir = mne.datasets.sample.data_path()
+    sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
+    raw = mne.io.read_raw_fif(sample_fname).pick_types('mag')
+    raw.resample(250)
+    raw.filter(1, 100)
+    ica = mne.preprocessing.ICA(n_components=20, max_iter='auto', method='infomax')
+    ica.fit(raw)
+    
+    res = megnet_label_components(raw, ica)
+


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------
### MEGnet Integration

Hi everyone, 

I integrated **[MEGnet](https://github.com/DeepLearningForPrecisionHealthLab/MegNET_2020)**  into `mne_icalabel/megnet`. Here’s a summary of the main work:

1. **ONNX Conversion**: Transformed the original Keras model into ONNX format and confirmed that the prediction outputs remain consistent. 
   
2. **Feature Simulation**: Added `megnet/features.py` to simulate the **BrainStorm ICA topomap** used in MEGnet training (for cases where MNE's ICA topomap is used ).
   
3.  **Prediction Function Simplification**: Refined the prediction logic in `megnet/label_components.py` for simplicity. Also, the outputs now align with the current EEG `label_components`, using the keys:
   - `label`
   - `y_pred_proba`

You can run the following commands to check out the prediction performance of MEGnet on MNE’s sample data:

```bash
python megnet/features.py
python megnet/label_components.py
```
However, to successfully integrate into mne-icalabel, changes need to be made to the contents of `mne-icalabel/label_components`. I’m worried that, given my understanding of the project, I might mess it up, so all the work is only within mne_icalabel/megnet.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] All CIs are happy
- [ ] Updated a changelog entry and contributor name in [whats_new.rst](https://github.com/mne-tools/mne-icalabel/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
